### PR TITLE
Add SHA256 fuzzy version hash check

### DIFF
--- a/common/fingerprints/parser/parser.go
+++ b/common/fingerprints/parser/parser.go
@@ -38,6 +38,7 @@ type HttpRule struct {
 type FuzzVersion struct {
 	Path         string `yaml:"path" json:"path"`
 	Pattern      string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
+	Hash         string `yaml:"hash,omitempty" json:"hash,omitempty"`
 	VersionRange string `yaml:"version_range" json:"version_range"`
 }
 

--- a/common/fingerprints/preload/fuzzversion_test.go
+++ b/common/fingerprints/preload/fuzzversion_test.go
@@ -1,12 +1,14 @@
 package preload
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/Tencent/AI-Infra-Guard/common/fingerprints/parser"
+	"github.com/Tencent/AI-Infra-Guard/common/utils"
 	"github.com/Tencent/AI-Infra-Guard/pkg/httpx"
 )
 
@@ -107,5 +109,43 @@ fuzzversion:
 	}
 	if ver != "1.2" {
 		t.Fatalf("expect 1.2 got %s", ver)
+	}
+}
+
+func TestEvalFpFuzzVersionHash(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hash", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hashcontent"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	expected := utils.BodyHash([]byte("hashcontent"))
+	yamlData := []byte(fmt.Sprintf(`
+info:
+  name: testfp
+  author: test
+  severity: info
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body=""
+fuzzversion:
+  - path: '/hash'
+    hash: '%s'
+    version_range: '>=1.0.0'
+`, expected))
+	fp, err := parser.InitFingerPrintFromData(yamlData)
+	if err != nil {
+		t.Fatalf("parse yaml: %v", err)
+	}
+	hp := newHTTPX(t)
+	ver, err := EvalFpVersion(srv.URL, hp, *fp)
+	if err != nil {
+		t.Fatalf("eval version: %v", err)
+	}
+	if ver != ">=1.0.0" {
+		t.Fatalf("expect >=1.0.0 got %s", ver)
 	}
 }

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"github.com/Tencent/AI-Infra-Guard/internal/gologger"
@@ -61,6 +62,12 @@ func FaviconHash(data []byte) int32 {
 	hasher := murmur3.New32WithSeed(0)
 	hasher.Write([]byte(stdBase64))
 	return int32(hasher.Sum32())
+}
+
+// BodyHash 计算响应内容的 SHA256 哈希值
+func BodyHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)
 }
 
 // ScanDir 递归扫描目录，返回所有文件的完整路径

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -51,6 +51,11 @@ func TestFaviconHash(t *testing.T) {
 	t.Log(hash)
 }
 
+func TestBodyHash(t *testing.T) {
+	h := BodyHash([]byte("hello"))
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", h)
+}
+
 func TestGetLocalOpenPorts(t *testing.T) {
 	op, err := GetLocalOpenPorts()
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- integrate SHA256 body hash utility into fuzz version detection
- remove hash token from general fingerprint rules
- support `hash` field for fuzzversion rules
- test new fuzzy version hash match

## Testing
- `go vet ./common/fingerprints/... ./common/utils...`
- `go test ./common/utils -run TestBodyHash -v`
- `go test ./common/fingerprints/preload -run TestEvalFpFuzzVersion -v`
- `go test ./common/fingerprints/preload -run TestEvalFpVersionIgnoreFuzz -v`
- `go test ./common/fingerprints/preload -run TestEvalFpFuzzVersionHash -v`
- `go test ./common/fingerprints/parser -run TestParseTokens -v`
- `go test ./common/fingerprints/parser -run TestEval -v`


------
https://chatgpt.com/codex/tasks/task_e_688658c7d258832dbdfa1766e60aacd7