### PR TITLE
feat: support fuzzy version range detection

### DIFF
--- a/common/fingerprints/parser/parser.go
+++ b/common/fingerprints/parser/parser.go
@@ -25,14 +25,24 @@ type Extractor struct {
 	Regex string `yaml:"regex" json:"regex"`
 }
 
+// VersionRangeRule defines range extraction for fuzzy version detection
+type VersionRangeRule struct {
+	Part  string `yaml:"part" json:"part"`
+	Group string `yaml:"group" json:"group"`
+	Regex string `yaml:"regex,omitempty" json:"regex,omitempty"`
+	Value string `yaml:"value,omitempty" json:"value,omitempty"`
+	Range string `yaml:"range" json:"range"`
+}
+
 // HttpRule 定义了HTTP请求匹配规则
 type HttpRule struct {
-	Method    string    `yaml:"method" json:"method"`
-	Path      string    `yaml:"path" json:"path"`
-	Matchers  []string  `yaml:"matchers" json:"matchers"`
-	Data      string    `yaml:"data,omitempty" json:"data,omitempty"`
-	dsl       []*Rule   `yaml:"-" json:"-"`
-	Extractor Extractor `yaml:"extractor,omitempty" json:"extractor,omitempty"`
+	Method    string             `yaml:"method" json:"method"`
+	Path      string             `yaml:"path" json:"path"`
+	Matchers  []string           `yaml:"matchers" json:"matchers"`
+	Data      string             `yaml:"data,omitempty" json:"data,omitempty"`
+	dsl       []*Rule            `yaml:"-" json:"-"`
+	Extractor Extractor          `yaml:"extractor,omitempty" json:"extractor,omitempty"`
+	Range     []VersionRangeRule `yaml:"versionRange,omitempty" json:"versionRange,omitempty"`
 }
 
 // GetDsl 返回解析后的DSL规则列表
@@ -110,8 +120,9 @@ func InitFingerPrintFromData(reader []byte) (*FingerPrint, error) {
 
 // FpResult 指纹结构体
 type FpResult struct {
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Name         string `json:"name"`
+	Version      string `json:"version,omitempty"`
+	VersionRange string `json:"version_range,omitempty"`
 }
 
 // Eval 评估配置是否匹配规则

--- a/common/fingerprints/preload/preload_version_test.go
+++ b/common/fingerprints/preload/preload_version_test.go
@@ -1,0 +1,73 @@
+package preload
+
+import (
+	"testing"
+
+	"github.com/Tencent/AI-Infra-Guard/common/fingerprints/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalFpVersionWithRange(t *testing.T) {
+	fp := parser.FingerPrint{
+		Version: []parser.HttpRule{
+			{
+				Method: "GET",
+				Path:   "/",
+				Extractor: parser.Extractor{
+					Part:  "body",
+					Group: "1",
+					Regex: `"version":"([0-9.]+)"`,
+				},
+				Range: []parser.VersionRangeRule{
+					{
+						Part:  "body",
+						Group: "1",
+						Regex: `"min":"([0-9.]+)"`,
+						Range: `version >= "{{value}}"`,
+					},
+					{
+						Part:  "body",
+						Group: "1",
+						Regex: `"max":"([0-9.]+)"`,
+						Range: `version <= "{{value}}"`,
+					},
+				},
+			},
+		},
+	}
+
+	config := &parser.Config{Body: `{"version":"2.1.0","min":"2.0.0","max":"2.5.0"}`}
+	version, ranges := extractVersionAndRanges(fp.Version[0], config, "")
+	require.Equal(t, "2.1.0", version)
+	require.Equal(t, []string{`version >= "2.0.0"`, `version <= "2.5.0"`}, ranges)
+}
+
+func TestEvalFpVersionRangeWithoutExact(t *testing.T) {
+	fp := parser.FingerPrint{
+		Version: []parser.HttpRule{
+			{
+				Method: "GET",
+				Path:   "/",
+				Range: []parser.VersionRangeRule{
+					{
+						Part:  "body",
+						Group: "1",
+						Regex: `"min":"([0-9.]+)"`,
+						Range: `version >= "{{value}}"`,
+					},
+					{
+						Part:  "body",
+						Group: "1",
+						Regex: `"max":"([0-9.]+)"`,
+						Range: `version < "{{value}}"`,
+					},
+				},
+			},
+		},
+	}
+
+	config := &parser.Config{Body: `{"min":"1.0.0","max":"1.9.9"}`}
+	version, ranges := extractVersionAndRanges(fp.Version[0], config, "")
+	require.Empty(t, version)
+	require.Equal(t, []string{`version >= "1.0.0"`, `version < "1.9.9"`}, ranges)
+}

--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -350,6 +350,9 @@ func (r *Runner) extractContent(fullUrl string, resp *httpx.Response, respTime s
 			if item.Version != "" {
 				builder.WriteString(":")
 				builder.WriteString(item.Version)
+			} else if item.VersionRange != "" {
+				builder.WriteString(":")
+				builder.WriteString(item.VersionRange)
 			}
 			builder.WriteString("]")
 			builder.WriteString(" ")
@@ -538,6 +541,8 @@ func (r *Runner) handleOutput(wg *sizedwaitgroup.SizedWaitGroup) {
 				}
 				if fp.Version != "" {
 					fpString += ":" + fp.Version
+				} else if fp.VersionRange != "" {
+					fpString += ":" + fp.VersionRange
 				}
 			}
 			data = map[string]string{
@@ -608,6 +613,8 @@ func (r *Runner) writeResult(f *os.File, result HttpResult) {
 			}
 			if fp.Version != "" {
 				fpString += ":" + fp.Version
+			} else if fp.VersionRange != "" {
+				fpString += ":" + fp.VersionRange
 			}
 		}
 		if r.Options.Callback != nil {


### PR DESCRIPTION
## Summary
- add a versionRange configuration to fingerprint rules so fuzzy version bounds can be extracted alongside exact versions
- propagate version range data through the preload runner and CLI output while preserving precise detections
- add unit coverage for extracting versions and intersecting range expressions from HTTP responses

## Testing
- go test ./common/fingerprints/preload -run TestEvalFpVersionWithRange -count=1 -v *(fails: go tooling cannot complete because required module github.com/Tencent/AI-Infra-Guard/internal/mcp/models is unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_69076ef8374483218bfffcda1282a55f