### PR TITLE
Refine fingerprint deduplication and formatting

### DIFF
--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -52,9 +52,10 @@ func formatFingerprints(fps []preload.FpResult) string {
 		return ""
 	}
 
-	parts := make([]string, 0, len(fps))
+parts := make([]string, 0, len(fps))
+	var builder strings.Builder
 	for _, fp := range fps {
-		builder := strings.Builder{}
+		builder.Reset()
 		builder.WriteString("[")
 		builder.WriteString(fp.Name)
 		if fp.Type != "" {


### PR DESCRIPTION
## Summary
- simplify the fingerprint deduplication logic by tracking the best result per name
- add a shared formatter for fingerprints so summary and callback output handle multiple entries correctly

## Testing
- go test ./common/fingerprints/preload -run TestEvalFpVersionWithRange -v *(hangs in this environment, aborted)*

------
https://chatgpt.com/codex/tasks/task_b_690783060a888328a123c17eeaf78f6e