### PR TITLE
Refactor fingerprint version range handling

### DIFF
--- a/common/fingerprints/preload/preload_version_test.go
+++ b/common/fingerprints/preload/preload_version_test.go
@@ -18,20 +18,7 @@ func TestEvalFpVersionWithRange(t *testing.T) {
 					Group: "1",
 					Regex: `"version":"([0-9.]+)"`,
 				},
-				Range: []parser.VersionRangeRule{
-					{
-						Part:  "body",
-						Group: "1",
-						Regex: `"min":"([0-9.]+)"`,
-						Range: `version >= "{{value}}"`,
-					},
-					{
-						Part:  "body",
-						Group: "1",
-						Regex: `"max":"([0-9.]+)"`,
-						Range: `version <= "{{value}}"`,
-					},
-				},
+				VersionRange: `version >= "2.0.0" && version <= "2.5.0"`,
 			},
 		},
 	}
@@ -39,29 +26,16 @@ func TestEvalFpVersionWithRange(t *testing.T) {
 	config := &parser.Config{Body: `{"version":"2.1.0","min":"2.0.0","max":"2.5.0"}`}
 	version, ranges := extractVersionAndRanges(fp.Version[0], config, "")
 	require.Equal(t, "2.1.0", version)
-	require.Equal(t, []string{`version >= "2.0.0"`, `version <= "2.5.0"`}, ranges)
+	require.Equal(t, []string{`version >= "2.0.0" && version <= "2.5.0"`}, ranges)
 }
 
 func TestEvalFpVersionRangeWithoutExact(t *testing.T) {
 	fp := parser.FingerPrint{
 		Version: []parser.HttpRule{
 			{
-				Method: "GET",
-				Path:   "/",
-				Range: []parser.VersionRangeRule{
-					{
-						Part:  "body",
-						Group: "1",
-						Regex: `"min":"([0-9.]+)"`,
-						Range: `version >= "{{value}}"`,
-					},
-					{
-						Part:  "body",
-						Group: "1",
-						Regex: `"max":"([0-9.]+)"`,
-						Range: `version < "{{value}}"`,
-					},
-				},
+				Method:       "GET",
+				Path:         "/",
+				VersionRange: `version >= "1.0.0" && version < "1.9.9"`,
 			},
 		},
 	}
@@ -69,5 +43,5 @@ func TestEvalFpVersionRangeWithoutExact(t *testing.T) {
 	config := &parser.Config{Body: `{"min":"1.0.0","max":"1.9.9"}`}
 	version, ranges := extractVersionAndRanges(fp.Version[0], config, "")
 	require.Empty(t, version)
-	require.Equal(t, []string{`version >= "1.0.0"`, `version < "1.9.9"`}, ranges)
+	require.Equal(t, []string{`version >= "1.0.0" && version < "1.9.9"`}, ranges)
 }


### PR DESCRIPTION
## Summary
- update fingerprint parser to store fuzzy version detection ranges directly on HTTP rules
- reuse matcher DSL parsing for version rules to support regex/hash based fuzzy checks
- simplify preload version extraction logic and align tests with the new version_range field

## Testing
- `go test ./...` *(fails: missing module github.com/Tencent/AI-Infra-Guard/internal/mcp/models)*

------
https://chatgpt.com/codex/tasks/task_b_6907968289b0832898e583d2d3c70e27