### PR TITLE
Add fuzzy version range support to fingerprint evaluation

### DIFF
--- a/common/fingerprints/preload/version_detection_test.go
+++ b/common/fingerprints/preload/version_detection_test.go
@@ -1,0 +1,133 @@
+package preload
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Tencent/AI-Infra-Guard/common/fingerprints/parser"
+	"github.com/Tencent/AI-Infra-Guard/pkg/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+func newHTTPXForTest(t *testing.T) *httpx.HTTPX {
+	t.Helper()
+	httpOptions := &httpx.HTTPOptions{
+		Timeout:          5 * time.Second,
+		RetryMax:         1,
+		FollowRedirects:  false,
+		HTTPProxy:        "",
+		Unsafe:           false,
+		DefaultUserAgent: httpx.GetRandomUserAgent(),
+		Dialer:           nil,
+	}
+	hp, err := httpx.NewHttpx(httpOptions)
+	assert.NoError(t, err)
+	return hp
+}
+
+func TestEvalFpVersionExact(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/exact" {
+			w.Header().Set("X-Version", "1.2.3")
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	data := `info:
+  name: test
+  author: test
+  severity: info
+  metadata:
+    product: test
+    vendor: test
+version:
+  - method: GET
+    path: '/exact'
+    extractor:
+      part: header
+      group: '1'
+      regex: 'X-Version:\s*([0-9.]+)'
+`
+	fp, err := parser.InitFingerPrintFromData([]byte(data))
+	assert.NoError(t, err)
+
+	hp := newHTTPXForTest(t)
+	version, err := EvalFpVersion(server.URL, hp, *fp)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3", version)
+}
+
+func TestEvalFpVersionFuzzyIntersection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/fuzzy1":
+			_, _ = w.Write([]byte("range-one"))
+		case "/fuzzy2":
+			_, _ = w.Write([]byte("range-two"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	data := `info:
+  name: test
+  author: test
+  severity: info
+  metadata:
+    product: test
+    vendor: test
+version:
+  - method: GET
+    path: '/fuzzy1'
+    matchers:
+      - body="range-one"
+    versionrange: '>=1.0.0,<2.0.0'
+  - method: GET
+    path: '/fuzzy2'
+    matchers:
+      - body="range-two"
+    versionrange: '>=1.5.0,<3.0.0'
+`
+	fp, err := parser.InitFingerPrintFromData([]byte(data))
+	assert.NoError(t, err)
+
+	hp := newHTTPXForTest(t)
+	version, err := EvalFpVersion(server.URL, hp, *fp)
+	assert.NoError(t, err)
+	assert.Equal(t, ">=1.5.0,<2.0.0", version)
+}
+
+func TestEvalFpVersionFuzzyNoMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("no-match"))
+	}))
+	defer server.Close()
+
+	data := `info:
+  name: test
+  author: test
+  severity: info
+  metadata:
+    product: test
+    vendor: test
+version:
+  - method: GET
+    path: '/fuzzy'
+    matchers:
+      - body="another"
+    versionrange: '>=1.0.0,<2.0.0'
+`
+	fp, err := parser.InitFingerPrintFromData([]byte(data))
+	assert.NoError(t, err)
+
+	hp := newHTTPXForTest(t)
+	version, err := EvalFpVersion(server.URL, hp, *fp)
+	assert.NoError(t, err)
+	assert.Equal(t, "", version)
+}

--- a/common/fingerprints/preload/version_range.go
+++ b/common/fingerprints/preload/version_range.go
@@ -1,0 +1,218 @@
+package preload
+
+import (
+	"fmt"
+	"strings"
+
+	vv "github.com/hashicorp/go-version"
+)
+
+type versionRange struct {
+	min          *vv.Version
+	max          *vv.Version
+	minInclusive bool
+	maxInclusive bool
+}
+
+func parseVersionRange(rangeStr string) (versionRange, error) {
+	s := strings.TrimSpace(rangeStr)
+	if s == "" {
+		return versionRange{}, fmt.Errorf("empty version range")
+	}
+
+	var vr versionRange
+
+	if (strings.HasPrefix(s, "[") || strings.HasPrefix(s, "(")) &&
+		(strings.HasSuffix(s, "]") || strings.HasSuffix(s, ")")) {
+		minInclusive := strings.HasPrefix(s, "[")
+		maxInclusive := strings.HasSuffix(s, "]")
+		content := strings.TrimSpace(s[1 : len(s)-1])
+		bounds := strings.Split(content, ",")
+		if len(bounds) != 2 {
+			return versionRange{}, fmt.Errorf("invalid range format: %s", rangeStr)
+		}
+		if min := strings.TrimSpace(bounds[0]); min != "" {
+			v, err := vv.NewVersion(min)
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyLowerBound(v, minInclusive)
+		}
+		if max := strings.TrimSpace(bounds[1]); max != "" {
+			v, err := vv.NewVersion(max)
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyUpperBound(v, maxInclusive)
+		}
+		if !vr.isValid() {
+			return versionRange{}, fmt.Errorf("invalid range: %s", rangeStr)
+		}
+		return vr, nil
+	}
+
+	parts := strings.Split(s, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(part, ">="):
+			v, err := vv.NewVersion(strings.TrimSpace(part[2:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyLowerBound(v, true)
+		case strings.HasPrefix(part, ">"):
+			v, err := vv.NewVersion(strings.TrimSpace(part[1:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyLowerBound(v, false)
+		case strings.HasPrefix(part, "<="):
+			v, err := vv.NewVersion(strings.TrimSpace(part[2:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyUpperBound(v, true)
+		case strings.HasPrefix(part, "<"):
+			v, err := vv.NewVersion(strings.TrimSpace(part[1:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyUpperBound(v, false)
+		case strings.HasPrefix(part, "=="):
+			v, err := vv.NewVersion(strings.TrimSpace(part[2:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyLowerBound(v, true)
+			vr.applyUpperBound(v, true)
+		case strings.HasPrefix(part, "="):
+			v, err := vv.NewVersion(strings.TrimSpace(part[1:]))
+			if err != nil {
+				return versionRange{}, err
+			}
+			vr.applyLowerBound(v, true)
+			vr.applyUpperBound(v, true)
+		default:
+			v, err := vv.NewVersion(part)
+			if err != nil {
+				return versionRange{}, fmt.Errorf("invalid version constraint: %s", part)
+			}
+			vr.applyLowerBound(v, true)
+			vr.applyUpperBound(v, true)
+		}
+	}
+
+	if !vr.isValid() {
+		return versionRange{}, fmt.Errorf("invalid range: %s", rangeStr)
+	}
+
+	return vr, nil
+}
+
+func (vr *versionRange) applyLowerBound(v *vv.Version, inclusive bool) {
+	if vr.min == nil {
+		vr.min = v
+		vr.minInclusive = inclusive
+		return
+	}
+
+	if v.GreaterThan(vr.min) {
+		vr.min = v
+		vr.minInclusive = inclusive
+		return
+	}
+
+	if v.Equal(vr.min) {
+		vr.minInclusive = vr.minInclusive && inclusive
+	}
+}
+
+func (vr *versionRange) applyUpperBound(v *vv.Version, inclusive bool) {
+	if vr.max == nil {
+		vr.max = v
+		vr.maxInclusive = inclusive
+		return
+	}
+
+	if v.LessThan(vr.max) {
+		vr.max = v
+		vr.maxInclusive = inclusive
+		return
+	}
+
+	if v.Equal(vr.max) {
+		vr.maxInclusive = vr.maxInclusive && inclusive
+	}
+}
+
+func (vr versionRange) isValid() bool {
+	if vr.min == nil || vr.max == nil {
+		return true
+	}
+
+	if vr.min.GreaterThan(vr.max) {
+		return false
+	}
+
+	if vr.min.Equal(vr.max) && (!vr.minInclusive || !vr.maxInclusive) {
+		return false
+	}
+
+	return true
+}
+
+func (vr versionRange) String() string {
+	if vr.min == nil && vr.max == nil {
+		return ""
+	}
+
+	if vr.min != nil && vr.max != nil && vr.min.Equal(vr.max) && vr.minInclusive && vr.maxInclusive {
+		return "=" + vr.min.String()
+	}
+
+	parts := make([]string, 0, 2)
+	if vr.min != nil {
+		op := ">"
+		if vr.minInclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, vr.min.String()))
+	}
+	if vr.max != nil {
+		op := "<"
+		if vr.maxInclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, vr.max.String()))
+	}
+	return strings.Join(parts, ",")
+}
+
+func intersectVersionRanges(ranges []versionRange) (versionRange, bool) {
+	if len(ranges) == 0 {
+		return versionRange{}, false
+	}
+
+	var result versionRange
+	for _, r := range ranges {
+		if r.min != nil {
+			result.applyLowerBound(r.min, r.minInclusive)
+		}
+		if r.max != nil {
+			result.applyUpperBound(r.max, r.maxInclusive)
+		}
+		if !result.isValid() {
+			return versionRange{}, false
+		}
+	}
+
+	if result.min == nil && result.max == nil {
+		return versionRange{}, false
+	}
+
+	return result, true
+}

--- a/common/fingerprints/preload/version_range_test.go
+++ b/common/fingerprints/preload/version_range_test.go
@@ -1,0 +1,57 @@
+package preload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersionRangeComparators(t *testing.T) {
+	vr, err := parseVersionRange(">=1.0.0,<2.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, ">=1.0.0,<2.0.0", vr.String())
+}
+
+func TestParseVersionRangeBracketNotation(t *testing.T) {
+	vr, err := parseVersionRange("[1.2.0,2.3.0)")
+	assert.NoError(t, err)
+	assert.Equal(t, ">=1.2.0,<2.3.0", vr.String())
+}
+
+func TestParseVersionRangeEquality(t *testing.T) {
+	vr, err := parseVersionRange("1.5.1")
+	assert.NoError(t, err)
+	assert.Equal(t, "=1.5.1", vr.String())
+}
+
+func TestIntersectVersionRanges(t *testing.T) {
+	r1, err := parseVersionRange(">=1.0.0,<2.0.0")
+	assert.NoError(t, err)
+	r2, err := parseVersionRange(">=1.5.0,<3.0.0")
+	assert.NoError(t, err)
+
+	result, ok := intersectVersionRanges([]versionRange{r1, r2})
+	assert.True(t, ok)
+	assert.Equal(t, ">=1.5.0,<2.0.0", result.String())
+}
+
+func TestIntersectVersionRangesEquality(t *testing.T) {
+	r1, err := parseVersionRange(">=1.0.0")
+	assert.NoError(t, err)
+	r2, err := parseVersionRange("=1.5.0")
+	assert.NoError(t, err)
+
+	result, ok := intersectVersionRanges([]versionRange{r1, r2})
+	assert.True(t, ok)
+	assert.Equal(t, "=1.5.0", result.String())
+}
+
+func TestIntersectVersionRangesEmpty(t *testing.T) {
+	r1, err := parseVersionRange(">=2.0.0")
+	assert.NoError(t, err)
+	r2, err := parseVersionRange("<1.0.0")
+	assert.NoError(t, err)
+
+	_, ok := intersectVersionRanges([]versionRange{r1, r2})
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary
- extend HttpRule to accept optional version ranges and reuse matcher compilation for version rules
- implement version range parsing/intersection utilities and integrate fuzzy handling into EvalFpVersion while retaining exact extraction
- add unit tests covering version extraction and range logic

## Testing
- go test ./common/fingerprints/preload -run TestEvalFpVersionExact -count=1
- go test ./common/fingerprints/preload -run TestEvalFpVersionFuzzyIntersection -count=1

------
https://chatgpt.com/codex/tasks/task_b_690851e7aa888328a4206a89f9ed5ffd