### PR TITLE
Merge hash into matchers for efficiency

### DIFF
--- a/common/fingerprints/parser/parser_test.go
+++ b/common/fingerprints/parser/parser_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestSingleRule(t *testing.T) {
-	rule := "body~=\"123123\" && (title == \"title\" || header=\"X-Powered-By: Express\")"
+	rule := "body~=\"123123\" && (body == \"title\" || header=\"X-Powered-By: Express\")"
 	config := &Config{
 		Body:   "1111231232233",
-		Header: "",
+		Header: "Server: nginx\r\nX-Powered-By: Express\r\n",
 		Icon:   23333,
 	}
 	tokens, err := ParseTokens(rule)
@@ -26,7 +26,7 @@ func TestSingleRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, dsl.Eval(config), true)
+	assert.True(t, dsl.Eval(config))
 }
 
 func TestSingleRuleForParse(t *testing.T) {

--- a/common/fingerprints/parser/synax_test.go
+++ b/common/fingerprints/parser/synax_test.go
@@ -3,7 +3,7 @@ package parser
 import "testing"
 
 func TestTransFormExp(t *testing.T) {
-	s := "header=\"realm=\\\"Comtrend Gigabit 802.11n Router\" || banner=\"Comtrend Gigabit 802.11n Router\""
+	s := "header=\"realm=\\\"Comtrend Gigabit 802.11n Router\" || body=\"Comtrend Gigabit 802.11n Router\""
 	tokens, err := ParseTokens(s)
 	if err != nil {
 		t.Fatal(err)

--- a/common/fingerprints/parser/token.go
+++ b/common/fingerprints/parser/token.go
@@ -19,6 +19,7 @@ const (
 	tokenBody   = "body"   // matches body content
 	tokenHeader = "header" // matches HTTP headers
 	tokenIcon   = "icon"   // matches icon content
+	tokenHash   = "hash"   // matches response hash
 	tokenText   = "text"   // matches text content
 
 	// Comparison operators
@@ -49,7 +50,7 @@ const (
 // ParseTokens converts input string to token sequence, supporting text content(quoted),
 // comparison ops(=,==,!=,~=), logical ops(&&,||), parentheses and keywords(body,header,icon)
 func ParseTokens(s1 string) ([]Token, error) {
-	return parseTokensWithOptions(s1, []string{tokenBody, tokenHeader, tokenIcon})
+	return parseTokensWithOptions(s1, []string{tokenBody, tokenHeader, tokenIcon, tokenHash})
 }
 
 // ParseAdvisorTokens parses advisor expressions, similar to ParseTokens but supports version keyword

--- a/common/fingerprints/preload/preload.go
+++ b/common/fingerprints/preload/preload.go
@@ -86,20 +86,17 @@ func (r *Runner) RunFpReqs(uri string, concurrent int, faviconHash int32) []FpRe
 				if resp == nil {
 					continue
 				}
-				// 文件指纹
+				sum := sha256.Sum256(resp.Data)
+				respHash := hex.EncodeToString(sum[:])
 				fpConfig := parser.Config{
 					Body:   resp.DataStr,
 					Header: resp.GetHeaderRaw(),
 					Icon:   faviconHash,
+					Hash:   respHash,
 				}
 
 				matched := false
-				if hash := strings.TrimSpace(req.Hash); hash != "" {
-					sum := sha256.Sum256(resp.Data)
-					if strings.EqualFold(hex.EncodeToString(sum[:]), hash) {
-						matched = true
-					}
-				} else if len(req.GetDsl()) == 0 {
+				if len(req.GetDsl()) == 0 {
 					matched = true
 				} else {
 					for _, dsl := range req.GetDsl() {
@@ -214,19 +211,17 @@ func EvalFpVersion(uri string, hp *httpx.HTTPX, fp parser.FingerPrint) (string, 
 			continue
 		}
 
+		sum := sha256.Sum256(resp.Data)
+		respHash := hex.EncodeToString(sum[:])
 		fpConfig := &parser.Config{
 			Body:   resp.DataStr,
 			Header: resp.GetHeaderRaw(),
 			Icon:   0,
+			Hash:   respHash,
 		}
 
 		matched := false
-		if hash := strings.TrimSpace(req.Hash); hash != "" {
-			sum := sha256.Sum256(resp.Data)
-			if strings.EqualFold(hex.EncodeToString(sum[:]), hash) {
-				matched = true
-			}
-		} else if len(req.GetDsl()) == 0 {
+		if len(req.GetDsl()) == 0 {
 			matched = true
 		} else {
 			for _, dsl := range req.GetDsl() {

--- a/common/fingerprints/preload/version_detection_test.go
+++ b/common/fingerprints/preload/version_detection_test.go
@@ -117,21 +117,23 @@ func TestEvalFpVersionFuzzyHashIntersection(t *testing.T) {
 	defer server.Close()
 
 	data := `info:
-  name: test
-  author: test
-  severity: info
-  metadata:
-    product: test
-    vendor: test
-version:
-  - method: GET
-    path: '/fuzzy1'
-    hash: '012c14d354f49d6e682efaa1e8d3f1433ff7da7093b2b5964aac1302303f52b4'
-    versionrange: '>=1.0.0,<2.0.0'
-  - method: GET
-    path: '/fuzzy2'
-    hash: '1773f6ec9285e9d638a94a19375353fa9c8c891c732d80a996724ed8017fe196'
-    versionrange: '>=1.5.0,<3.0.0'
+    name: test
+    author: test
+    severity: info
+    metadata:
+      product: test
+      vendor: test
+  version:
+    - method: GET
+      path: '/fuzzy1'
+      matchers:
+        - hash=="012c14d354f49d6e682efaa1e8d3f1433ff7da7093b2b5964aac1302303f52b4"
+      versionrange: '>=1.0.0,<2.0.0'
+    - method: GET
+      path: '/fuzzy2'
+      matchers:
+        - hash=="1773f6ec9285e9d638a94a19375353fa9c8c891c732d80a996724ed8017fe196"
+      versionrange: '>=1.5.0,<3.0.0'
 `
 	fp, err := parser.InitFingerPrintFromData([]byte(data))
 	assert.NoError(t, err)


### PR DESCRIPTION
Merges the `hash` field into `matchers` by introducing a new `hash` keyword in the DSL.

Previously, `HttpRule` had separate `Matchers` and `Hash` fields, which were mutually exclusive and handled by distinct code paths. This change unifies the configuration interface by integrating hash-based matching directly into the DSL, allowing `hash=="..."` expressions within `matchers` while enforcing that hash matchers cannot be combined with other matcher types in the same rule.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6f52e18-cc48-4370-9df4-e41017e23f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6f52e18-cc48-4370-9df4-e41017e23f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `hash` matcher to the DSL and removes separate `HttpRule.Hash`, computing and passing response hashes at runtime while enforcing hash-only rules.
> 
> - **Parser**:
>   - Add `hash` keyword to tokens/AST, extend eval to read `Config.Hash`.
>   - Remove `HttpRule.Hash`; `HttpRule.Matchers` now supports `hash=="..."`.
>   - Compile-time validation: detect hash usage via `Rule.hashUsage()` and forbid mixing `hash` with other matcher types in the same rule.
>   - Extend `Config` with `Hash`.
> - **Runtime (preload)**:
>   - Compute SHA-256 of response body, set `Config.Hash`, and evaluate DSL uniformly for both `http` and `version` flows.
>   - Remove special-case hash logic; rely solely on DSL matchers.
> - **Tests**:
>   - Update parser and version detection tests to use `hash=="..."` in `matchers` and adjust assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db956d2004c06e5d1d28522d8e2311c3d1c5177c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->