### PR TITLE
Test version detection functions for errors

### DIFF
--- a/common/fingerprints/preload/version_detection_test.go
+++ b/common/fingerprints/preload/version_detection_test.go
@@ -117,23 +117,23 @@ func TestEvalFpVersionFuzzyHashIntersection(t *testing.T) {
 	defer server.Close()
 
 	data := `info:
-    name: test
-    author: test
-    severity: info
-    metadata:
-      product: test
-      vendor: test
-  version:
-    - method: GET
-      path: '/fuzzy1'
-      matchers:
-        - hash=="012c14d354f49d6e682efaa1e8d3f1433ff7da7093b2b5964aac1302303f52b4"
-      versionrange: '>=1.0.0,<2.0.0'
-    - method: GET
-      path: '/fuzzy2'
-      matchers:
-        - hash=="1773f6ec9285e9d638a94a19375353fa9c8c891c732d80a996724ed8017fe196"
-      versionrange: '>=1.5.0,<3.0.0'
+  name: test
+  author: test
+  severity: info
+  metadata:
+    product: test
+    vendor: test
+version:
+  - method: GET
+    path: '/fuzzy1'
+    matchers:
+      - hash=="012c14d354f49d6e682efaa1e8d3f1433ff7da7093b2b5964aac1302303f52b4"
+    versionrange: '>=1.0.0,<2.0.0'
+  - method: GET
+    path: '/fuzzy2'
+    matchers:
+      - hash=="1773f6ec9285e9d638a94a19375353fa9c8c891c732d80a996724ed8017fe196"
+    versionrange: '>=1.5.0,<3.0.0'
 `
 	fp, err := parser.InitFingerPrintFromData([]byte(data))
 	assert.NoError(t, err)


### PR DESCRIPTION
Fix YAML indentation in `TestEvalFpVersionFuzzyHashIntersection` to resolve parsing errors and nil pointer panics.

---
<a href="https://cursor.com/background-agent?bcId=bc-a637ec7b-71d9-4bdd-939f-dccc6baff6fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a637ec7b-71d9-4bdd-939f-dccc6baff6fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects YAML in TestEvalFpVersionFuzzyHashIntersection to parse fingerprints and validate the expected version range intersection by hash.
> 
> - **Tests**:
>   - Fix YAML structure in `common/fingerprints/preload/version_detection_test.go` for `TestEvalFpVersionFuzzyHashIntersection` (convert mis-indented list to proper mapping), ensuring `hash==...` matchers parse and the version range intersection resolves to `">=1.5.0,<2.0.0"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3a25caf518ee4f65174a6dcf6990ce75fdca8f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->